### PR TITLE
Move state to index.jsx

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
   "dependencies": {
     "firebase": "^2.3.2",
     "node-libs-browser": "0.5.3",
+    "re-base": "^1.5.0",
     "react": "0.14.6",
-    "react-dom": "0.14.6",
-    "rebase": "^0.3.0"
+    "react-dom": "0.14.6"
   },
   "devDependencies": {
     "babel-core": "6.4.0",

--- a/package.json
+++ b/package.json
@@ -25,9 +25,11 @@
   },
   "homepage": "https://github.com/alicoding/react-webpack-babel#readme",
   "dependencies": {
+    "firebase": "^2.3.2",
     "node-libs-browser": "0.5.3",
     "react": "0.14.6",
-    "react-dom": "0.14.6"
+    "react-dom": "0.14.6",
+    "rebase": "^0.3.0"
   },
   "devDependencies": {
     "babel-core": "6.4.0",

--- a/src/components/RecipeForm.jsx
+++ b/src/components/RecipeForm.jsx
@@ -1,13 +1,18 @@
 import React from 'react';
 
 export default class extends React.Component {
+
   render() {
     return (
       <div>
         <form>
 
           <div>
-            <input type="text" id="name" placeholder="Recipe Name" min="0"/>
+            <input type="text" 
+                   id="name" 
+                   placeholder="Recipe Name" 
+                   min="0"
+             />
           </div>
 
           <div>

--- a/src/components/RecipeForm.jsx
+++ b/src/components/RecipeForm.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+// I think the ingredients and steps inputs should be their own components.
+
 export default class extends React.Component {
 
   render() {
@@ -16,19 +18,28 @@ export default class extends React.Component {
           </div>
 
           <div>
-            <input type="number" id="prep" name="prep" placeholder="Prep Time in minutes" min="0"/>
+            <input type="number" 
+                   id="prep" 
+                   name="prep" 
+                   placeholder="Prep Time in minutes" 
+                   min="0"
+             />
           </div>
 
           <div>
-            <input type="number" id="cook" name="cook" placeholder="Cook Time"/>
+            <input type="number"
+                   id="cook" 
+                   name="cook" 
+                   placeholder="Cook Time"
+            />
           </div>
 
           <div>
-            <textarea id="ingredients" className="materialize-textarea" placeholder="Ingredients"></textarea>
+            <textarea id="ingredients" placeholder="Ingredients"></textarea>
           </div>
 
           <div>
-            <textarea id="steps" className="materialize-textarea" placeholder="Steps"></textarea>
+            <textarea id="steps" placeholder="Steps"></textarea>
           </div>
 
           <input id="add" type="submit" value="Add"/>

--- a/src/components/Recipes.jsx
+++ b/src/components/Recipes.jsx
@@ -1,56 +1,34 @@
 import React from 'react';
 
-export default class extends React.Component{
-  constructor() {
-    super();
-    this.state = {
-      recipes: [
-        {
-          name: "Mac and Cheese",
-          prep: 30,
-          cook: 60,
-          ingredients: ["Milk", "Cheese", "Macaroni"],
-          steps: ["Step 1", "Step 2", "Step 3"]
-        },
-        {
-          name: "Spagette",
-          prep: 10,
-          cook: 30,
-          ingredients: ["Tomato sauce", "Pasta", "MacaParmesaroni"],
-          steps: ["Step 1", "Step 2", "Step 3"]
-        }
-      ]
-    }  
-  }
+export default class Recipes extends React.Component{
   
   render() {
-
-    var recipe = this.state.recipes.map((recipe) => {
+    var recipe = this.props.recipes.map((recipe) => {
       return (
         <div>
           <ul>
             <li>{ recipe.name }</li>
             <li>{ recipe.prep }</li>
             <li>{ recipe.cook }</li>
-            <li>{ recipe.ingredients.map((ing) => { 
+            <li>Ingredients:{ recipe.ingredients.map((ing) => { 
               return (
-                <div>
-                  <ul>
-                    <li>{ ing }</li>
-                  </ul>
-                </div>
-              ) 
-            })}
+                    <div>
+                      <ul>
+                        <li>{ ing }</li>
+                      </ul>
+                    </div>
+                  ) 
+                 })}
             </li>
-            <li>{ recipe.steps.map((step) => { 
+            <li>Steps:{ recipe.steps.map((step) => { 
               return (
-                <div>
-                  <ul>
-                    <li>{ step }</li>
-                  </ul>
-                </div>
-              ) 
-            })}
+                    <div>
+                      <ul>
+                        <li>{ step }</li>
+                      </ul>
+                    </div>
+                  ) 
+                 })}
             </li>
           </ul>
         </div>

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -5,11 +5,31 @@ import RecipeForm from './components/RecipeForm';
 import Recipes from './components/Recipes';
 
 export class App extends React.Component {
+    constructor(props) {
+    super(props);
+    this.state = {
+      recipes: [
+        { name: 'Mac and Cheese',
+          prep: 10,
+          cook: 30,
+          ingredients: ["Milk", "Cheese", "Macaroni"],
+          steps: ["Step 1", "Step 2", "Step 3"]
+         }
+      ]
+    }  
+  }
+  
+  handleAddIngredient(newIng) {
+    this.setState({
+      ingredients: this.state.ingredients.concat([newIng])
+    })
+  }
+  
 	render() {
 		return (
       <div>
-        <RecipeForm />
-				<Recipes />
+        <RecipeForm add={this.handleAddIngredient.bind(this)}/>
+				<Recipes recipes={this.state.recipes}/>
       </div>
 		);
 	}


### PR DESCRIPTION
Each component shouldn't have their own state ( `this.state = {recipes: [...]...}` ) so I moved that into the index.jsx, and now we can pass the state down in props. 

You'll notice in the render method of our App, `<Recipe />` is now `<Recipe recipes={this.state.recipes} />` (ignore `<RecipeForm add={this.handleAddIngredient.bind(this)}/>` - it's from a previous attempt to get the form data that I forgot to take out). 

In Recipes.jsx, `var recipe` is now calling the state we passed in there: `var recipe = this.props.recipes.map(...)`. Pretty cool. It's a step toward using re-base/firebase.